### PR TITLE
fixed a typo, where description was not present after a colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The same error would occur if you were trying to update a record. So how do we f
 # app/controllers/posts_controller.rb
 
 def create
-  @post = Post.new(params.require(:post).permit(:title, :))
+  @post = Post.new(params.require(:post).permit(:title, :description))
   @post.save
   redirect_to post_path(@post)
 end


### PR DESCRIPTION
I believe that the word "description" should be included in this line, unless the intention was to provide code that did not work and had another error for students to find and fix.